### PR TITLE
Add Composer 2 Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+
+root = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
             "name": "Hari KT",
             "email": "kthari85@gmail.com",
             "homepage": "http://harikt.com"
+        },
+        {
+            "name": "Radon8472",
+            "email": "develop@raon-software.net",
+            "homepage": "https://github.com/Radon8472"
         }
     ],
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "hari/pw-module",    
-    "type": "composer-installer",
+    "type": "composer-plugin",
     "license": "BSD-2-Clause",
     "description": "Installs processwire 3rd party modules to PW system \"site/modules\" directory.",    
     "minimum-stability": "dev",
@@ -27,6 +27,9 @@
             "homepage": "https://github.com/Radon8472"
         }
     ],
+    "require": {
+        "composer-plugin-api": "^1.0 || ^2.0"
+    },
     "require-dev": {
         "composer/composer": "1.0.* || ^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         }
     },
     "extra" : {
-        "class" : "PW\\Composer\\Plugin"
+        "class" : "PW\\Composer\\Plugin",
+        "plugin-modifies-install-path": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
         }
     },
     "extra" : {
-        "class" : "PW\\Composer\\SystemInstaller"
+        "class" : "PW\\Composer\\Plugin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require-dev": {
-        "composer/composer": "1.0.*"
+        "composer/composer": "1.0.* || ^2.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "homepage": "http://harikt.com"
         }
     ],
+    "require-dev": {
+        "composer/composer": "1.0.*"
+    },
     "autoload": {
         "psr-0": {
             "PW\\Composer\\": "src/"

--- a/src/PW/Composer/Plugin.php
+++ b/src/PW/Composer/Plugin.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PW\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+/**
+ * The Plugin class
+ *
+ * @see https://getcomposer.org/doc/articles/plugins.md#plugin-class
+ */
+class Plugin implements PluginInterface
+{
+    /**
+     * Register installer
+     *
+     * @param Composer $composer
+     * @param IOInterface $io
+     */
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $installer = new SystemInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($installer);
+    }
+
+   /**
+    * Remove any hooks from Composer
+    *
+    * This will be called when a plugin is deactivated before being uninstalled, but also before it
+    * gets upgraded to a new version so the old one can be deactivated and the new one activated.
+    *
+    * @param Composer $composer
+    * @param IOInterface $io
+    */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+   /**
+    * Prepare the plugin to be uninstalled
+    *
+    * This will be called after deactivate.
+    *
+    * @param Composer    $composer
+    * @param IOInterface $io
+    */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+}

--- a/src/PW/Composer/SystemInstaller.php
+++ b/src/PW/Composer/SystemInstaller.php
@@ -14,6 +14,9 @@ class SystemInstaller extends LibraryInstaller
     {
         // do the installation
         parent::install($repo, $package);
+        $installPath = $this->getPackageBasePath($package);
+        if(!file_exists("$installPath/composer.json"))
+            $this->io->write(sprintf('<error>Files in "%s" not created</error>', $installPath));
     }
 
     /**
@@ -23,6 +26,9 @@ class SystemInstaller extends LibraryInstaller
     {
         // do the installation
         parent::uninstall($repo, $package);
+        $installPath = $this->getPackageBasePath($package);
+        if(file_exists("$installPath"))
+            $this->io->write(sprintf('<warning>Files in "%s" where not deleted</warning>', $installPath));
     }
 
     /**

--- a/src/PW/Composer/SystemInstaller.php
+++ b/src/PW/Composer/SystemInstaller.php
@@ -15,7 +15,7 @@ class SystemInstaller extends LibraryInstaller
         // do the installation
         parent::install($repo, $package);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -24,7 +24,7 @@ class SystemInstaller extends LibraryInstaller
         // do the installation
         parent::uninstall($repo, $package);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -42,7 +42,7 @@ class SystemInstaller extends LibraryInstaller
         list($vendor, $name) = $this->getVendorAndName($package);
         return "site/modules/{$name}";
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -50,16 +50,16 @@ class SystemInstaller extends LibraryInstaller
     {
         return $packageType == 'pw-module';
     }
-    
+
     /**
-     * 
+     *
      * Given a PackageInterface, returns the package vendor and name.
-     * 
+     *
      * @param PackageInterface $package The package to work with.
-     * 
+     *
      * @return array An array where element 0 is the package vendor and
      * element 1 is the package name.
-     * 
+     *
      */
     private function getVendorAndName(PackageInterface $package)
     {
@@ -68,15 +68,15 @@ class SystemInstaller extends LibraryInstaller
         $name = $this->ucSnakeWords($name);
         return array($vendor, $name);
     }
-    
+
     /**
-     * 
+     *
      * Converts "this-text" to "This_Text".
-     * 
+     *
      * @param string $text The string to convert.
-     * 
+     *
      * @return string The converted string.
-     * 
+     *
      */
     private function ucSnakeWords($text)
     {


### PR DESCRIPTION
This PR should fix #2 .

It now works with Composer V1 and V2 and removes the `legacy composer-installer built for Composer 1.x` warning (see https://github.com/harikt/pwmoduleinstaller/issues/2#issuecomment-855771881).

After merging this, you should create a matching versions tag (e.g. 1.0.1).