### PR TITLE
Update installer path - part 2 (improve hariktgh-4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "1.0.* || ^2.0"
+        "composer/composer": "^1.10.23 || ^2.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hari/pw-module",    
+    "name": "hari/pw-module",
     "type": "composer-plugin",
     "license": "BSD-2-Clause",
     "description": "Installs processwire 3rd party modules to PW system \"site/modules\" directory.",    

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.10.23 || ^2.0"
+        "composer/composer": "^1.10.23 || ^2.1.9"
     },
     "autoload": {
         "psr-0": {

--- a/src/PW/Composer/SystemInstaller.php
+++ b/src/PW/Composer/SystemInstaller.php
@@ -16,8 +16,16 @@ class SystemInstaller extends LibraryInstaller
         // do the installation
         $promise = parent::install($repo, $package);
         $installPath = $this->getPackageBasePath($package);
-        $outputStatus = function () use ($installPath) {
-            if (! is_dir($installPath)) {
+        list(, $name) = $this->getVendorAndName($package);
+        $outputStatus = function () use ($installPath, $name) {
+            $filesExists = false;
+            foreach (['module', 'module.php'] as $ext) {
+                if(file_exists("{$installPath}/{$name}.{$ext}")) {
+                    $filesExists = true;
+                    break;
+                }
+            }
+            if(!$filesExists) {
                 $this->io->write(sprintf('<error>Files in "%s" not created</error>', $installPath));
             }
         };


### PR DESCRIPTION
This PR changes the check for a successful install like diskussed in [harikt#4 (comment)].

Additional it fixes as minor issue with dev-depencies to calm dependabot (details in 277d099 and b27babc).

I recommend creating a versions-tag for 1.1.1 after merging this.




[harikt#4 (comment)]: https://github.com/harikt/pwmoduleinstaller/pull/4#issuecomment-1106044331